### PR TITLE
mypy, pyright: add object annotation to struct_fields

### DIFF
--- a/Pyright/main.py
+++ b/Pyright/main.py
@@ -104,7 +104,7 @@ def nesting_body_failure_f(x: FinalStr | FinalInt | bool) -> int:
 ## success
 class StructFieldsSuccessApple:
     def __init__(self, a):
-        self.a = a
+        self.a: object = a
 
 def struct_fields_success_f(x: StructFieldsSuccessApple) -> int:
     if type(x.a) is FinalInt:

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ define f(x: String | Number | Boolean) -> Number:
 
 ##### Description
 
-Partially refine the type of a struct, that is, when the predicate is applied to an struct field, refine the type of the field.
+Partially refine the type of an immutable struct, that is, when the predicate is applied to an struct field, refine the type of the field.
 
 ##### Examples
 
@@ -562,6 +562,26 @@ The results of these examples are demonstrated below.
 
 
 ## Other Discussions
+
+### mutation
+
+This benchmark assumes that all data is immutable.
+When data can be mutated, it is difficult to allow narrowing at all because safety depends
+on what control-flow is allowed and what (if any) code has concurrent access to the same data.
+
+For example in Python, it is in general unsound to assume that `self.parent` is not `None` for
+the following two additions, because the first field access (`self.parent.wins`) might in fact
+be a dynamic property access and it might overwrite `self.parent`:
+
+```
+if self.parent is not None:
+  total += self.parent.wins
+  total += self.parent.losses # may be unsound!
+```
+
+<https://github.com/facebookincubator/cinder/issues/145>
+
+
 
 ### refinement invalidation
 

--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,7 @@
 (define deps '("base" "gtp-util"))
 (define build-deps '("gtp-util"))
 (define pkg-desc "Benchmark for Type Narrowing")
-(define version "1.0")
+(define version "1.1")
 (define pkg-authors '(ben "hanwen.guo@utah.edu"))
 (define scribblings '())
 (define compile-omit-paths '("Flow" "Pyright" "TypeScript" "TypedRacket" "mypy"))

--- a/main.rkt
+++ b/main.rkt
@@ -104,9 +104,9 @@
                          (benchmark-output-transposed #t)]
    [("-e" "--examples") "Run the advanced examples"
                         (benchmark-run-examples #t)]
-   #:args ([type-checker-name null])
-   type-checker-name))
+   #:args type-checker-names
+   type-checker-names))
 
 (if (null? type-checker-arg)
     (run-benchmarks (map car typechecker-parameters-alist))
-    (run-benchmarks (list (string->symbol (string-downcase type-checker-arg)))))
+    (run-benchmarks (map (compose1 string->symbol string-downcase) type-checker-arg)))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -104,7 +104,7 @@ def nesting_body_failure_f(x: FinalStr | FinalInt | bool) -> int:
 ## success
 class StructFieldsSuccessApple:
     def __init__(self, a):
-        self.a = a
+        self.a: object = a
 
 def struct_fields_success_f(x: StructFieldsSuccessApple) -> int:
     if type(x.a) is FinalInt:


### PR DESCRIPTION
Add missing annotation to Python structs.

The Core If-T Benchmark says the struct field should be top.

DONE ~TODO~: clarify in the benchmark (`./README.md`) that structs are assumed immutable!