### PR TITLE
v1.1: clarify auxiliary helper functions

### DIFF
--- a/Flow/README.md
+++ b/Flow/README.md
@@ -7,7 +7,7 @@ Flow is a typechecker for JavaScript by Facebook.
   - <https://flow.org/en/docs/>
   - <https://github.com/facebook/flow>
   - <https://play.flow.com/>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./src/index.js](./src/index.js)
 * Raw command to run the benchmark: `touch .flowconfig && npx flow focus-check <path-to-file>`
 

--- a/Flow/src/index.js
+++ b/Flow/src/index.js
@@ -242,12 +242,12 @@ function merge_with_union_failure_f(x: mixed): string | number {
 
 // Example predicate_2way
 // success
-function predicate_2way_success_f(x: string | number): x is string {
+function predicate_2way_success_helper(x: string | number): x is string {
   return typeof x === "string";
 }
 
 function predicate_2way_success_g(x: string | number): number {
-  if (predicate_2way_success_f(x)) {
+  if (predicate_2way_success_helper(x)) {
     return x.length;
   } else {
     return x;
@@ -255,12 +255,12 @@ function predicate_2way_success_g(x: string | number): number {
 }
 
 // failure
-function predicate_2way_failure_f(x: string | number): x is string {
+function predicate_2way_failure_helper(x: string | number): x is string {
   return typeof x === "string";
 }
 
 function predicate_2way_failure_g(x: string | number): number {
-  if (predicate_2way_failure_f(x)) {
+  if (predicate_2way_failure_helper(x)) {
     return x + 1;
   } else {
     return x;
@@ -269,12 +269,12 @@ function predicate_2way_failure_g(x: string | number): number {
 
 // Example predicate_1way
 // success
-function predicate_1way_success_f(x: string | number): implies x is number {
+function predicate_1way_success_helper(x: string | number): implies x is number {
   return typeof x === "number" && x > 0;
 }
 
 function predicate_1way_success_g(x: string | number): number {
-  if (predicate_1way_success_f(x)) {
+  if (predicate_1way_success_helper(x)) {
     return x + 1;
   } else {
     return 0;
@@ -282,12 +282,12 @@ function predicate_1way_success_g(x: string | number): number {
 }
 
 // failure
-function predicate_1way_failure_f(x: string | number): implies x is number {
+function predicate_1way_failure_helper(x: string | number): implies x is number {
   return typeof x === "number" && x > 0;
 }
 
 function predicate_1way_failure_g(x: string | number): number {
-  if (predicate_1way_failure_f(x)) {
+  if (predicate_1way_failure_helper(x)) {
     return x + 1;
   } else {
     return x.length;
@@ -296,12 +296,12 @@ function predicate_1way_failure_g(x: string | number): number {
 
 // Example predicate_checked
 // success
-function predicate_checked_success_f(x: string | number | boolean): x is string {
+function predicate_checked_success_helper(x: string | number | boolean): x is string {
   return typeof x === "string";
 }
 
 function predicate_checked_success_g(x: string | number | boolean): x is number | boolean {
-  return !predicate_checked_success_f(x);
+  return !predicate_checked_success_helper(x);
 }
 
 // failure

--- a/Pyright/README.md
+++ b/Pyright/README.md
@@ -9,7 +9,7 @@ through the Pylance plugin.
   - <https://github.com/microsoft/pyright>
   - <https://pyright-play.net/>
   - <https://peps.python.org/pep-0484/>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./main.py](./main.py)
 * Raw command to run the benchmark: `npx pyright <path-to-file>`
 

--- a/Pyright/main.py
+++ b/Pyright/main.py
@@ -216,53 +216,53 @@ def merge_with_union_failure_f(x: object) -> str | int:
 
 ## Example predicate_2way
 ## success
-def predicate_2way_success_f(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
+def predicate_2way_success_helper(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_2way_success_g(x: FinalStr | FinalInt) -> int:
-    if predicate_2way_success_f(x):
+    if predicate_2way_success_helper(x):
         return len(x)
     else:
         return x
 
 ## failure
-def predicate_2way_failure_f(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
+def predicate_2way_failure_helper(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_2way_failure_g(x: FinalStr | FinalInt) -> int:
-    if predicate_2way_failure_f(x):
+    if predicate_2way_failure_helper(x):
         return x + 1
     else:
         return x
 
 ## Example predicate_1way
 ## success
-def predicate_1way_success_f(x: FinalStr | FinalInt) -> TypeGuard[int]:
+def predicate_1way_success_helper(x: FinalStr | FinalInt) -> TypeGuard[int]:
     return type(x) is FinalInt and x > 0
 
 def predicate_1way_success_g(x: FinalStr | FinalInt) -> int:
-    if predicate_1way_success_f(x):
+    if predicate_1way_success_helper(x):
         return x + 1
     else:
         return 0
 
 ## failure
-def predicate_1way_failure_f(x: FinalStr | FinalInt) -> TypeGuard[int]:
+def predicate_1way_failure_helper(x: FinalStr | FinalInt) -> TypeGuard[int]:
     return type(x) is FinalInt and x > 0
 
 def predicate_1way_failure_g(x: FinalStr | FinalInt) -> int:
-    if predicate_1way_failure_f(x):
+    if predicate_1way_failure_helper(x):
         return x + 1
     else:
         return len(x)
 
 ## Example predicate_checked
 ## success
-def predicate_checked_success_f(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:
+def predicate_checked_success_helper(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_checked_success_g(x: FinalStr | FinalInt | bool) -> TypeIs[FinalInt | bool]:
-    return not predicate_checked_success_f(x)
+    return not predicate_checked_success_helper(x)
 
 ## failure
 def predicate_checked_failure_f(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # If T: Type Narrowing Benchmark
 
-[Version 1.0](https://github.com/utahplt/ifT-benchmark/releases)
+[Version 1.1](https://github.com/utahplt/ifT-benchmark/releases)
 
 Benchmark for Type Narrowing (aka Occurrence Typing, aka Type Refinement).
 
@@ -420,11 +420,13 @@ When a custom predicate is true, the type of the variable is refined to a more s
 ###### Success Expected
 
 ```text
-define f(x: String | Number) -> x is String:
+define helper(x: String | Number) -> x is String:
+    // helper function: this is a custom predicate
     return x is String
 
 define g(x: String | Number) -> Number:
-    if f(x):
+    // main test function: this code uses a custom predicate
+    if helper(x):
         return String.length(x) // type of x is refined to String
     else:
         return x // type of x is refined to Number, namely (String | Number) - String
@@ -433,11 +435,11 @@ define g(x: String | Number) -> Number:
 ###### Failure Expected
 
 ```text
-define f(x: String | Number) -> x is String:
+define helper(x: String | Number) -> x is String: // auxilliary helper function
     return x is String
 
-define g(x: String | Number) -> Number:
-    if f(x):
+define g(x: String | Number) -> Number: // main test case
+    if helper(x):
         return x + 1 // type of x is refined to String, adding a number to a string is not allowed
     else:
         return x // type of x is refined to Number, namely (String | Number) - String
@@ -454,11 +456,11 @@ When a custom predicate is true, the type of the variable is refined to a more s
 ###### Success Expected
 
 ```text
-define f(x: String | Number) -> implies x is Number:
+define helper(x: String | Number) -> implies x is Number: // auxilliary helper function
     return x is Number and x > 0
 
-define g(x: String | Number) -> Number:
-    if f(x):
+define g(x: String | Number) -> Number: // main test case
+    if helper(x):
         return x + 1 // type of x is refined to Number
     else:
         return 0
@@ -467,11 +469,11 @@ define g(x: String | Number) -> Number:
 ###### Failure Expected
 
 ```text
-define f(x: String | Number) -> implies x is Number:
+define helper(x: String | Number) -> implies x is Number: // auxilliary helper function
     return x is Number and x > 0
 
-define g(x: String | Number) -> Number:
-    if f(x):
+define g(x: String | Number) -> Number: // main test case
+    if helper(x):
         return x + 1 // type of x is refined to Number
     else:
         return String.length(x) // type of x is not refined, thus not compatible with the return type
@@ -488,20 +490,20 @@ The type checker checks that the body of a custom predicate really checks the ty
 ###### Success Expected
 
 ```text
-define f(x: String | Number | Boolean) -> x is String:
+define helper(x: String | Number | Boolean) -> x is String: // auxilliary helper function
     return x is String
 
-define g(x: String | Number | Boolean) -> x is Number | Boolean:
-    return not f(x)
+define g(x: String | Number | Boolean) -> x is Number | Boolean: // main test case
+    return not helper(x)
 ```
 
 ###### Failure Expected
 
 ```text
-define f(x: String | Number | Boolean) -> x is String:
+define f(x: String | Number | Boolean) -> x is String: // main test case 1
     return x is String or x is Number // may return true when predicate is false
 
-define g(x: String | Number | Boolean) -> x is Number | Boolean:
+define g(x: String | Number | Boolean) -> x is Number | Boolean: // main test case 2
     return x is Number // may return false when predicate is true
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ define g(x: String | Number) -> Number:
 ###### Failure Expected
 
 ```text
-define helper(x: String | Number) -> x is String: // auxilliary helper function
+define helper(x: String | Number) -> x is String: // auxiliary helper function
     return x is String
 
 define g(x: String | Number) -> Number: // main test case
@@ -456,7 +456,7 @@ When a custom predicate is true, the type of the variable is refined to a more s
 ###### Success Expected
 
 ```text
-define helper(x: String | Number) -> implies x is Number: // auxilliary helper function
+define helper(x: String | Number) -> implies x is Number: // auxiliary helper function
     return x is Number and x > 0
 
 define g(x: String | Number) -> Number: // main test case
@@ -469,7 +469,7 @@ define g(x: String | Number) -> Number: // main test case
 ###### Failure Expected
 
 ```text
-define helper(x: String | Number) -> implies x is Number: // auxilliary helper function
+define helper(x: String | Number) -> implies x is Number: // auxiliary helper function
     return x is Number and x > 0
 
 define g(x: String | Number) -> Number: // main test case
@@ -490,7 +490,7 @@ The type checker checks that the body of a custom predicate really checks the ty
 ###### Success Expected
 
 ```text
-define helper(x: String | Number | Boolean) -> x is String: // auxilliary helper function
+define helper(x: String | Number | Boolean) -> x is String: // auxiliary helper function
     return x is String
 
 define g(x: String | Number | Boolean) -> x is Number | Boolean: // main test case

--- a/Sorbet/README.md
+++ b/Sorbet/README.md
@@ -8,7 +8,7 @@ Sorbet adds static types to Ruby.
   - <https://github.com/sorbet/sorbet>
   - <https://sorbet.org/docs/gradual>
   - <https://sorbet.org/docs/from-typescript>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./main.rb](./main.rb), [./examples.rb](./examples.rb)
 * Raw command to run the benchmark: `srb tc main.rb`, `srb tc examples.rb` (or, using `bundler`: `bundle exec srb tc main.rb`, `bundle exec srb tc examples.rb`)
 

--- a/Sorbet/main.rb
+++ b/Sorbet/main.rb
@@ -277,7 +277,7 @@ end
 ## Example predicate_2way
 ## success
 sig { params(x: T.any(String, Integer)).returns(T::Boolean) }
-def predicate_2way_success_f(x)
+def predicate_2way_success_helper(x)
   raise "Sorbet does not support type predicates"
 end
 
@@ -288,7 +288,7 @@ end
 
 ## failure
 sig { params(x: T.any(String, Integer)).returns(T::Boolean) }
-def predicate_2way_failure_f(x)
+def predicate_2way_failure_helper(x)
   raise "Sorbet does not support type predicates"
 end
 
@@ -300,7 +300,7 @@ end
 ## Example predicate_1way
 ## success
 sig { params(x: T.any(String, Integer)).returns(T::Boolean) }
-def predicate_1way_success_f(x)
+def predicate_1way_success_helper(x)
   raise "Sorbet does not support type predicates"
 end
 
@@ -311,7 +311,7 @@ end
 
 ## failure
 sig { params(x: T.any(String, Integer)).returns(T::Boolean) }
-def predicate_1way_failure_f(x)
+def predicate_1way_failure_helper(x)
   raise "Sorbet does not support type predicates"
 end
 
@@ -323,7 +323,7 @@ end
 ## Example predicate_checked
 ## success
 sig { params(x: T.any(String, Integer, TrueClass, FalseClass)).returns(T::Boolean) }
-def predicate_checked_success_f(x)
+def predicate_checked_success_helper(x)
   raise "Sorbet does not support type predicates"
 end
 

--- a/TypeScript/README.md
+++ b/TypeScript/README.md
@@ -7,7 +7,7 @@ TypeScript is a typechecker for JavaScript by Microsoft.
   - <https://www.typescriptlang.org/>
   - <https://github.com/microsoft/TypeScript>
   - <https://www.typescriptlang.org/play>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./main.ts](./main.ts)
 * Raw command to run the benchmark: `tsc --noEmit --target es2023 <path-to-file>`
 

--- a/TypeScript/main.ts
+++ b/TypeScript/main.ts
@@ -240,12 +240,12 @@ function merge_with_union_failure_f(x: unknown): string | number {
 
 // Example predicate_2way
 // success
-function predicate_2way_success_f(x: string | number): x is string {
+function predicate_2way_success_helper(x: string | number): x is string {
   return typeof x === "string";
 }
 
 function predicate_2way_success_g(x: string | number): number {
-  if (predicate_2way_success_f(x)) {
+  if (predicate_2way_success_helper(x)) {
     return x.length;
   } else {
     return x;
@@ -253,12 +253,12 @@ function predicate_2way_success_g(x: string | number): number {
 }
 
 // failure
-function predicate_2way_failure_f(x: string | number): x is string {
+function predicate_2way_failure_helper(x: string | number): x is string {
   return typeof x === "string";
 }
 
 function predicate_2way_failure_g(x: string | number): number {
-  if (predicate_2way_failure_f(x)) {
+  if (predicate_2way_failure_helper(x)) {
     return x + 1;
   } else {
     return x;
@@ -267,12 +267,12 @@ function predicate_2way_failure_g(x: string | number): number {
 
 // Example predicate_1way
 // success
-function predicate_1way_success_f(x: string | number): x is number {
+function predicate_1way_success_helper(x: string | number): x is number {
   return typeof x === "number" && x > 0;
 }
 
 function predicate_1way_success_g(x: string | number): number {
-  if (predicate_1way_success_f(x)) {
+  if (predicate_1way_success_helper(x)) {
     return x + 1;
   } else {
     return 0;
@@ -280,12 +280,12 @@ function predicate_1way_success_g(x: string | number): number {
 }
 
 // failure
-function predicate_1way_failure_f(x: string | number): x is number {
+function predicate_1way_failure_helper(x: string | number): x is number {
   return typeof x === "number" && x > 0;
 }
 
 function predicate_1way_failure_g(x: string | number): number {
-  if (predicate_1way_failure_f(x)) {
+  if (predicate_1way_failure_helper(x)) {
     return x + 1;
   } else {
     return x.length;
@@ -294,12 +294,12 @@ function predicate_1way_failure_g(x: string | number): number {
 
 // Example predicate_checked
 // success
-function predicate_checked_success_f(x: string | number | boolean): x is string {
+function predicate_checked_success_helper(x: string | number | boolean): x is string {
   return typeof x === "string";
 }
 
 function predicate_checked_success_g(x: string | number | boolean): x is number | boolean {
-  return !predicate_checked_success_f(x);
+  return !predicate_checked_success_helper(x);
 }
 
 // failure

--- a/TypedRacket/README.md
+++ b/TypedRacket/README.md
@@ -8,7 +8,7 @@ Typed Racket adds gradual types to Racket.
   - <https://github.com/racket/typed-racket>
   - <https://www2.ccs.neu.edu/racket/pubs/popl08-thf.pdf>
   - <https://www2.ccs.neu.edu/racket/pubs/icfp10-thf.pdf>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./main.rkt](./main.rkt)
 * Raw command to run the benchmark: `racket <path-to-file>`
 

--- a/TypedRacket/main.rkt
+++ b/TypedRacket/main.rkt
@@ -179,55 +179,55 @@
 
 ;; Example predicate_2way
 ;; success
-(: predicate-2way-success-f (-> (U String Number) Boolean : String))
-(define (predicate-2way-success-f x)
+(: predicate-2way-success-helper (-> (U String Number) Boolean : String))
+(define (predicate-2way-success-helper x)
   (string? x))
 
 (define (predicate-2way-success-g [x : (U String Number)]) : Number
-  (if (predicate-2way-success-f x)
+  (if (predicate-2way-success-helper x)
       (string-length x)
       x))
 
 ;; failure
-(: predicate-2way-failure-f (-> (U String Number) Boolean : String))
-(define (predicate-2way-failure-f x)
+(: predicate-2way-failure-helper (-> (U String Number) Boolean : String))
+(define (predicate-2way-failure-helper x)
   (string? x))
 
 (define (predicate-2way-failure-g [x : (U String Number)]) : Number
-  (if (predicate-2way-failure-f x)
+  (if (predicate-2way-failure-helper x)
       (+ 1 x)
       x))
 
 ;; Example predicate_1way
 ;; success
-(: predicate-1way-success-f (-> (U String Integer) Boolean : #:+ Integer))
-(define (predicate-1way-success-f x)
+(: predicate-1way-success-helper (-> (U String Integer) Boolean : #:+ Integer))
+(define (predicate-1way-success-helper x)
   (and (number? x) (> x 0)))
 
 (define (predicate-1way-success-g [x : (U String Integer)]) : Integer
-  (if (predicate-1way-success-f x)
+  (if (predicate-1way-success-helper x)
       (+ 1 x)
       0))
 
 ;; failure
-(: predicate-1way-failure-f (-> (U String Integer) Boolean : #:+ Integer))
-(define (predicate-1way-failure-f x)
+(: predicate-1way-failure-helper (-> (U String Integer) Boolean : #:+ Integer))
+(define (predicate-1way-failure-helper x)
   (and (number? x) (> x 0)))
 
 (define (predicate-1way-failure-g [x : (U String Integer)]) : Integer
-  (if (predicate-1way-failure-f x)
+  (if (predicate-1way-failure-helper x)
       (+ 1 x)
       (string-length x)))
 
 ;; Example predicate_checked
 ;; success
-(: predicate-checked-success-f (-> (U String Number Boolean) Boolean : String))
-(define (predicate-checked-success-f x)
+(: predicate-checked-success-helper (-> (U String Number Boolean) Boolean : String))
+(define (predicate-checked-success-helper x)
   (string? x))
 
 (: predicate-checked-success-g (-> (U String Number Boolean) Boolean : (U Number Boolean)))
 (define (predicate-checked-success-g x)
-  (not (predicate-checked-success-f x)))
+  (not (predicate-checked-success-helper x)))
 
 ;; failure
 (: predicate-checked-failure-f (-> (U String Number Boolean) Boolean : String))

--- a/mypy/README.md
+++ b/mypy/README.md
@@ -8,7 +8,7 @@ mypy is a typechecker for Python PEP 484 types.
   - <https://github.com/python/mypy>
   - <https://mypy-play.net/?mypy=latest&python=3.12>
   - <https://peps.python.org/pep-0484/>
-* If-T version: **1.0**
+* If-T version: **1.1**
 * Implementation: [./main.py](./main.py)
 * Raw command to run the benchmark: `source .venv/bin/activate && mypy <path-to-file>`
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -216,53 +216,53 @@ def merge_with_union_failure_f(x: object) -> str | int:
 
 ## Example predicate_2way
 ## success
-def predicate_2way_success_f(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
+def predicate_2way_success_helper(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_2way_success_g(x: FinalStr | FinalInt) -> int:
-    if predicate_2way_success_f(x):
+    if predicate_2way_success_helper(x):
         return len(x)
     else:
         return x
 
 ## failure
-def predicate_2way_failure_f(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
+def predicate_2way_failure_helper(x: FinalStr | FinalInt) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_2way_failure_g(x: FinalStr | FinalInt) -> int:
-    if predicate_2way_failure_f(x):
+    if predicate_2way_failure_helper(x):
         return x + 1
     else:
         return x
 
 ## Example predicate_1way
 ## success
-def predicate_1way_success_f(x: FinalStr | FinalInt) -> TypeGuard[int]:
+def predicate_1way_success_helper(x: FinalStr | FinalInt) -> TypeGuard[int]:
     return type(x) is FinalInt and x > 0
 
 def predicate_1way_success_g(x: FinalStr | FinalInt) -> int:
-    if predicate_1way_success_f(x):
+    if predicate_1way_success_helper(x):
         return x + 1
     else:
         return 0
 
 ## failure
-def predicate_1way_failure_f(x: FinalStr | FinalInt) -> TypeGuard[int]:
+def predicate_1way_failure_helper(x: FinalStr | FinalInt) -> TypeGuard[int]:
     return type(x) is FinalInt and x > 0
 
 def predicate_1way_failure_g(x: FinalStr | FinalInt) -> int:
-    if predicate_1way_failure_f(x):
+    if predicate_1way_failure_helper(x):
         return x + 1
     else:
         return len(x)
 
 ## Example predicate_checked
 ## success
-def predicate_checked_success_f(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:
+def predicate_checked_success_helper(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:
     return type(x) is FinalStr
 
 def predicate_checked_success_g(x: FinalStr | FinalInt | bool) -> TypeIs[FinalInt | bool]:
-    return not predicate_checked_success_f(x)
+    return not predicate_checked_success_helper(x)
 
 ## failure
 def predicate_checked_failure_f(x: FinalStr | FinalInt | bool) -> TypeIs[FinalStr]:


### PR DESCRIPTION
rename helper functions to use the word "helper" instead of calling them "f" like normal test functions

add comments in README.md to clarify the purpose of helpers

this affects only the custom predicate benchmarks

@hanwenguo please take a look, because this PR bumps the version number (v1.1). Note that I did the simplest possible renaming: `f` -> `helper`, and didn't also rename functions from `g` -> `f`, which would be more consistent with the rest of the benchmark, but seems like more trouble than it's worth because calling the first test `f` is not a good convention in the first place.